### PR TITLE
Add parallax hero effects

### DIFF
--- a/ServeX Website/contact.html
+++ b/ServeX Website/contact.html
@@ -134,6 +134,30 @@
             font-size: 1.5rem;
             margin-bottom: 15px;
         }
+        /* Decorative shapes for hero parallax */
+        .shape {
+            position: absolute;
+            pointer-events: none;
+            transition: transform 0.2s ease-out;
+        }
+        .shape-1 {
+            width: 180px;
+            height: 180px;
+            background: linear-gradient(135deg, #66bb6a, #3d8b40);
+            clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+            top: -50px;
+            left: -50px;
+            z-index: 0;
+        }
+        .shape-2 {
+            width: 260px;
+            height: 260px;
+            background: linear-gradient(135deg, #dcedc8, #a5d6a7);
+            clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+            bottom: -70px;
+            right: -70px;
+            z-index: 0;
+        }
     </style>
     <script>
         tailwind.config = {
@@ -177,8 +201,10 @@
     </nav>
 
     <!-- Contact Hero Section -->
-    <section class="contact-gradient py-16 md:py-20 px-6 animate-on-scroll">
-        <div class="max-w-[90rem] mx-auto text-center">
+    <section class="contact-gradient py-16 md:py-20 px-6 relative overflow-hidden animate-on-scroll">
+        <div class="shape shape-1" data-speed="25"></div>
+        <div class="shape shape-2" data-speed="40"></div>
+        <div class="max-w-[90rem] mx-auto text-center relative">
             <div class="max-w-3xl mx-auto">
                 <h1 class="text-4xl md:text-5xl font-bold text-gray-800 leading-tight mb-6">
                     We're Here to Help
@@ -709,6 +735,16 @@
                     behavior: 'smooth',
                     block: 'start'
                 });
+            });
+        });
+
+        // Simple parallax effect for hero shapes
+        document.addEventListener('mousemove', function(e) {
+            document.querySelectorAll('.shape').forEach(shape => {
+                const speed = parseFloat(shape.dataset.speed) || 20;
+                const x = (window.innerWidth / 2 - e.clientX) / speed;
+                const y = (window.innerHeight / 2 - e.clientY) / speed;
+                shape.style.transform = `translate(${x}px, ${y}px)`;
             });
         });
     </script>

--- a/ServeX Website/index.html
+++ b/ServeX Website/index.html
@@ -112,6 +112,30 @@
             border-bottom: 3px solid #66bb6a;
             color: #66bb6a;
         }
+        /* Decorative shapes for hero parallax */
+        .shape {
+            position: absolute;
+            pointer-events: none;
+            transition: transform 0.2s ease-out;
+        }
+        .shape-1 {
+            width: 220px;
+            height: 220px;
+            background: linear-gradient(135deg, #66bb6a, #3d8b40);
+            clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+            top: -60px;
+            left: -60px;
+            z-index: 0;
+        }
+        .shape-2 {
+            width: 300px;
+            height: 300px;
+            background: linear-gradient(135deg, #dcedc8, #a5d6a7);
+            clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+            bottom: -80px;
+            right: -80px;
+            z-index: 0;
+        }
     </style>
 </head>
 <body class="bg-gray-50">
@@ -154,8 +178,10 @@
     </nav>
 
     <!-- Hero Section -->
-    <section id="home" class="hero-gradient py-16 md:py-24 px-6 animate-on-scroll">
-        <div class="max-w-[90rem] mx-auto">
+    <section id="home" class="hero-gradient py-16 md:py-24 px-6 relative overflow-hidden animate-on-scroll">
+        <div class="shape shape-1" data-speed="25"></div>
+        <div class="shape shape-2" data-speed="40"></div>
+        <div class="max-w-[90rem] mx-auto relative">
             <div class="flex flex-col md:flex-row items-center">
                 <div class="md:w-1/2 mb-10 md:mb-0">
                     <h1 class="text-4xl md:text-5xl font-bold text-gray-800 leading-tight mb-6">
@@ -1517,6 +1543,16 @@
                         if (otherContent) otherContent.classList.add('hidden');
                     }
                 });
+            });
+        });
+
+        // Simple parallax effect for hero shapes
+        document.addEventListener('mousemove', function(e) {
+            document.querySelectorAll('.shape').forEach(shape => {
+                const speed = parseFloat(shape.dataset.speed) || 20;
+                const x = (window.innerWidth / 2 - e.clientX) / speed;
+                const y = (window.innerHeight / 2 - e.clientY) / speed;
+                shape.style.transform = `translate(${x}px, ${y}px)`;
             });
         });
     </script>


### PR DESCRIPTION
## Summary
- add parallax decorative shapes to hero sections
- animate shapes with mouse move to mimic MetaMask-style effects

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b708d1220832db1c5f8f1f95c733b