### PR TITLE
Add floating tool parallax layer

### DIFF
--- a/ServeX Website/contact.html
+++ b/ServeX Website/contact.html
@@ -158,6 +158,31 @@
             right: -70px;
             z-index: 0;
         }
+        /* Floating tool icons */
+        .floating-tool {
+            position: absolute;
+            width: 80px;
+            opacity: 0.15;
+            pointer-events: none;
+            z-index: 1;
+            will-change: transform;
+            transform-style: preserve-3d;
+        }
+        .floating-tool .tool-inner {
+            width: 100%;
+            height: 100%;
+            animation: tool-sway 8s ease-in-out infinite;
+        }
+        @keyframes tool-sway {
+            0%,100% { transform: rotate(-2deg); }
+            50% { transform: rotate(2deg); }
+        }
+        @media (max-width: 640px) {
+            .floating-tool { opacity: 0.08; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .floating-tool { display: none; }
+        }
     </style>
     <script>
         tailwind.config = {
@@ -173,6 +198,57 @@
     </script>
 </head>
 <body class="bg-gray-50">
+    <!-- Floating Tools Layer -->
+    <div class="floating-tool" data-speed="15" style="top:120px; left:6%;">
+        <div class="tool-inner">
+            <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <rect x="27" y="5" width="6" height="30" rx="3" />
+                <path d="M10 40h40l-5 15H15z" />
+            </svg>
+        </div>
+    </div>
+    <div class="floating-tool" data-speed="20" style="top:200px; right:8%;">
+        <div class="tool-inner">
+            <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <path d="M2 18l10-10 6 6-4 4 20 20 4-4 6 6-10 10-6-6 4-4L12 24l-4 4-6-6z"/>
+            </svg>
+        </div>
+    </div>
+    <div class="floating-tool" data-speed="25" style="top:800px; left:10%;">
+        <div class="tool-inner">
+            <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <rect x="10" y="10" width="30" height="10" />
+                <rect x="38" y="20" width="4" height="12" />
+                <rect x="32" y="30" width="8" height="20" />
+            </svg>
+        </div>
+    </div>
+    <div class="floating-tool" data-speed="30" style="top:1200px; right:10%;">
+        <div class="tool-inner">
+            <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <rect x="10" y="40" width="30" height="10" />
+                <rect x="25" y="10" width="5" height="30" />
+                <rect x="30" y="5" width="15" height="5" />
+            </svg>
+        </div>
+    </div>
+    <div class="floating-tool" data-speed="35" style="top:1800px; left:15%;">
+        <div class="tool-inner">
+            <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <circle cx="30" cy="25" r="15" />
+                <rect x="25" y="40" width="10" height="10" />
+                <rect x="23" y="50" width="14" height="5" />
+            </svg>
+        </div>
+    </div>
+    <div class="floating-tool" data-speed="40" style="top:2100px; right:12%;">
+        <div class="tool-inner">
+            <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <rect x="10" y="20" width="40" height="25" rx="2" />
+                <rect x="20" y="10" width="20" height="10" rx="2" />
+            </svg>
+        </div>
+    </div>
     <!-- Navigation -->
     <nav class="bg-white shadow-sm py-3 px-6 z-50 transition-all duration-300">
         <div class="max-w-[90rem] mx-auto flex justify-between items-center">
@@ -746,6 +822,19 @@
                 const y = (window.innerHeight / 2 - e.clientY) / speed;
                 shape.style.transform = `translate(${x}px, ${y}px)`;
             });
+        });
+    </script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const tools = document.querySelectorAll('.floating-tool');
+            const updateTools = () => {
+                tools.forEach(tool => {
+                    const speed = parseFloat(tool.dataset.speed) || 20;
+                    tool.style.transform = `translateY(${window.scrollY / speed}px)`;
+                });
+            };
+            updateTools();
+            window.addEventListener('scroll', updateTools);
         });
     </script>
 </body>

--- a/ServeX Website/index.html
+++ b/ServeX Website/index.html
@@ -136,9 +136,85 @@
             right: -80px;
             z-index: 0;
         }
+        /* Floating tool icons */
+        .floating-tool {
+            position: absolute;
+            width: 80px;
+            opacity: 0.15;
+            pointer-events: none;
+            z-index: 1;
+            will-change: transform;
+            transform-style: preserve-3d;
+        }
+        .floating-tool .tool-inner {
+            width: 100%;
+            height: 100%;
+            animation: tool-sway 8s ease-in-out infinite;
+        }
+        @keyframes tool-sway {
+            0%,100% { transform: rotate(-2deg); }
+            50% { transform: rotate(2deg); }
+        }
+        @media (max-width: 640px) {
+            .floating-tool { opacity: 0.08; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .floating-tool { display: none; }
+        }
     </style>
 </head>
 <body class="bg-gray-50">
+    <!-- Floating Tools Layer -->
+    <div class="floating-tool" data-speed="15" style="top:150px; left:5%;">
+        <div class="tool-inner">
+            <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <rect x="27" y="5" width="6" height="30" rx="3" />
+                <path d="M10 40h40l-5 15H15z" />
+            </svg>
+        </div>
+    </div>
+    <div class="floating-tool" data-speed="20" style="top:220px; right:10%;">
+        <div class="tool-inner">
+            <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <path d="M2 18l10-10 6 6-4 4 20 20 4-4 6 6-10 10-6-6 4-4L12 24l-4 4-6-6z"/>
+            </svg>
+        </div>
+    </div>
+    <div class="floating-tool" data-speed="25" style="top:900px; left:8%;">
+        <div class="tool-inner">
+            <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <rect x="10" y="10" width="30" height="10" />
+                <rect x="38" y="20" width="4" height="12" />
+                <rect x="32" y="30" width="8" height="20" />
+            </svg>
+        </div>
+    </div>
+    <div class="floating-tool" data-speed="30" style="top:1300px; right:5%;">
+        <div class="tool-inner">
+            <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <rect x="10" y="40" width="30" height="10" />
+                <rect x="25" y="10" width="5" height="30" />
+                <rect x="30" y="5" width="15" height="5" />
+            </svg>
+        </div>
+    </div>
+    <div class="floating-tool" data-speed="35" style="top:2200px; left:15%;">
+        <div class="tool-inner">
+            <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <circle cx="30" cy="25" r="15" />
+                <rect x="25" y="40" width="10" height="10" />
+                <rect x="23" y="50" width="14" height="5" />
+            </svg>
+        </div>
+    </div>
+    <div class="floating-tool" data-speed="40" style="top:2600px; right:15%;">
+        <div class="tool-inner">
+            <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <rect x="10" y="20" width="40" height="25" rx="2" />
+                <rect x="20" y="10" width="20" height="10" rx="2" />
+            </svg>
+        </div>
+    </div>
     <!-- Early Access Banner -->
     <div class="bg-[#3d8b40] text-white py-2 px-4 sticky top-0 z-50 flex flex-wrap items-center justify-center gap-2" id="early-access-banner">
         <span class="font-medium">Join our early access list:</span>
@@ -1554,6 +1630,19 @@
                 const y = (window.innerHeight / 2 - e.clientY) / speed;
                 shape.style.transform = `translate(${x}px, ${y}px)`;
             });
+        });
+    </script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const tools = document.querySelectorAll('.floating-tool');
+            const updateTools = () => {
+                tools.forEach(tool => {
+                    const speed = parseFloat(tool.dataset.speed) || 20;
+                    tool.style.transform = `translateY(${window.scrollY / speed}px)`;
+                });
+            };
+            updateTools();
+            window.addEventListener('scroll', updateTools);
         });
     </script>
 


### PR DESCRIPTION
## Summary
- add floating-tool styles and sway animation
- include six decorative SVG tool icons on each page
- implement scroll-based parallax movement in vanilla JS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b78de9e4c832db2194509dc2841c5